### PR TITLE
Feature/translatable fields

### DIFF
--- a/DiscordLab.Bot/API/Features/MessageContent.cs
+++ b/DiscordLab.Bot/API/Features/MessageContent.cs
@@ -164,10 +164,8 @@ public class MessageContent
     /// </summary>
     /// <param name="field">The field to check.</param>
     /// <returns>Whether the field is present in the <see cref="TranslatedFields"/>.</returns>
-    public bool FieldMarkedTranslatable(TranslatableMessageField field)
-    {
-        return (TranslatedFields & field) != 0;
-    }
+    public bool FieldMarkedTranslatable(TranslatableMessageField field) =>
+        (TranslatedFields & field) != 0;
 
     /// <summary>
     /// Builds the embed and/or content assigned to this <see cref="MessageContent"/> using a <see cref="TranslationBuilder"/>.

--- a/DiscordLab.Bot/API/Features/MessageContent.cs
+++ b/DiscordLab.Bot/API/Features/MessageContent.cs
@@ -1,10 +1,8 @@
 // ReSharper disable MemberCanBePrivate.Global
 
-using System.ComponentModel;
-using DiscordLab.Bot.API.Features.Embed;
-
 namespace DiscordLab.Bot.API.Features;
 
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 using Discord.Rest;

--- a/DiscordLab.Bot/API/Features/MessageContent.cs
+++ b/DiscordLab.Bot/API/Features/MessageContent.cs
@@ -1,5 +1,8 @@
 // ReSharper disable MemberCanBePrivate.Global
 
+using System.ComponentModel;
+using DiscordLab.Bot.API.Features.Embed;
+
 namespace DiscordLab.Bot.API.Features;
 
 using System.Diagnostics;
@@ -16,6 +19,12 @@ using YamlDotNet.Serialization;
 /// </summary>
 public class MessageContent
 {
+    private const TranslatableMessageField DefaultTranslatableFields =
+        TranslatableMessageField.Message |
+        TranslatableMessageField.EmbedDescription |
+        TranslatableMessageField.EmbedFieldValues |
+        TranslatableMessageField.EmbedFooterText;
+
     /// <summary>
     /// Gets or sets the embed to send, if any.
     /// </summary>
@@ -27,6 +36,13 @@ public class MessageContent
     /// </summary>
     [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets which parts of the message should have their placeholders replaced.
+    /// </summary>
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    [DefaultValue(DefaultTranslatableFields)]
+    public TranslatableMessageField TranslatedFields { get; set; } = DefaultTranslatableFields;
 
     /// <summary>
     /// Converts an embed into a <see cref="MessageContent"/> instance.
@@ -146,6 +162,16 @@ public class MessageContent
     }
 
     /// <summary>
+    /// Checks whether the specified field has been marked as translatable in <see cref="TranslatedFields"/>.
+    /// </summary>
+    /// <param name="field">The field to check.</param>
+    /// <returns>Whether the field is present in the <see cref="TranslatedFields"/>.</returns>
+    public bool FieldMarkedTranslatable(TranslatableMessageField field)
+    {
+        return (TranslatedFields & field) != 0;
+    }
+
+    /// <summary>
     /// Builds the embed and/or content assigned to this <see cref="MessageContent"/> using a <see cref="TranslationBuilder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="TranslationBuilder"/> to use.</param>
@@ -153,7 +179,7 @@ public class MessageContent
     /// <exception cref="ArgumentException">Throws when message content is too long after being built.</exception>
     public (Discord.Embed? Embed, string? Content) Build(TranslationBuilder builder)
     {
-        string? content = Message != null ? builder.Build(Message) : null;
+        string? content = Message != null && FieldMarkedTranslatable(TranslatableMessageField.Message) ? builder.Build(Message) : null;
 
         if (content is { Length: > Discord.DiscordConfig.MaxMessageSize })
             throw new ArgumentException($"Message content is too long, length must be less or equal to {Discord.DiscordConfig.MaxMessageSize}. This is after compiling the message.", nameof(Message));
@@ -162,16 +188,52 @@ public class MessageContent
             return (null, content);
 
         Discord.EmbedBuilder embed = Embed;
-        if (!string.IsNullOrEmpty(embed.Description))
+
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedTitle) && !string.IsNullOrEmpty(embed.Title))
+            embed.Title = builder.Build(embed.Title);
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedDescription) && !string.IsNullOrEmpty(embed.Description))
             embed.Description = builder.Build(embed.Description);
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedUrl) && !string.IsNullOrEmpty(embed.Url))
+            embed.Url = builder.Build(embed.Url);
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedThumbnailUrl) && !string.IsNullOrEmpty(embed.ThumbnailUrl))
+            embed.ThumbnailUrl = builder.Build(embed.ThumbnailUrl);
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedImageUrl) && !string.IsNullOrEmpty(embed.ImageUrl))
+            embed.ImageUrl = builder.Build(embed.ImageUrl);
 
-        if (embed.Footer != null && !string.IsNullOrEmpty(embed.Footer.Text))
-            embed.Footer.Text = builder.Build(embed.Footer.Text);
-
-        foreach (Discord.EmbedFieldBuilder field in embed.Fields)
+        if (embed.Author != null)
         {
-            if (field.Value is string value && !string.IsNullOrEmpty(value))
-                field.Value = builder.Build(value);
+            if (FieldMarkedTranslatable(TranslatableMessageField.EmbedAuthorName) && !string.IsNullOrEmpty(embed.Author.Name))
+                embed.Author.Name = builder.Build(embed.Author.Name);
+            if (FieldMarkedTranslatable(TranslatableMessageField.EmbedAuthorUrl) && !string.IsNullOrEmpty(embed.Author.Url))
+                embed.Author.Url = builder.Build(embed.Author.Url);
+            if (FieldMarkedTranslatable(TranslatableMessageField.EmbedAuthorIconUrl) && !string.IsNullOrEmpty(embed.Author.IconUrl))
+                embed.Author.IconUrl = builder.Build(embed.Author.IconUrl);
+        }
+
+        if (embed.Footer != null)
+        {
+            if (FieldMarkedTranslatable(TranslatableMessageField.EmbedFooterText) && !string.IsNullOrEmpty(embed.Footer.Text))
+                embed.Footer.Text = builder.Build(embed.Footer.Text);
+            if (FieldMarkedTranslatable(TranslatableMessageField.EmbedFooterIconUrl) && !string.IsNullOrEmpty(embed.Footer.IconUrl))
+                embed.Footer.IconUrl = builder.Build(embed.Footer.IconUrl);
+        }
+
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedFieldNames))
+        {
+            foreach (Discord.EmbedFieldBuilder field in embed.Fields)
+            {
+                if (!string.IsNullOrEmpty(field.Name))
+                    field.Name = builder.Build(field.Name);
+            }
+        }
+
+        if (FieldMarkedTranslatable(TranslatableMessageField.EmbedFieldValues))
+        {
+            foreach (Discord.EmbedFieldBuilder field in embed.Fields)
+            {
+                if (field.Value is string value && !string.IsNullOrEmpty(value))
+                    field.Value = builder.Build(value);
+            }
         }
 
         return (embed.Build(), content);

--- a/DiscordLab.Bot/API/Features/MessageContent.cs
+++ b/DiscordLab.Bot/API/Features/MessageContent.cs
@@ -175,7 +175,7 @@ public class MessageContent
     /// <exception cref="ArgumentException">Throws when message content is too long after being built.</exception>
     public (Discord.Embed? Embed, string? Content) Build(TranslationBuilder builder)
     {
-        string? content = Message != null && FieldMarkedTranslatable(TranslatableMessageField.Message) ? builder.Build(Message) : null;
+        string? content = Message != null && FieldMarkedTranslatable(TranslatableMessageField.Message) ? builder.Build(Message) : Message;
 
         if (content is { Length: > Discord.DiscordConfig.MaxMessageSize })
             throw new ArgumentException($"Message content is too long, length must be less or equal to {Discord.DiscordConfig.MaxMessageSize}. This is after compiling the message.", nameof(Message));

--- a/DiscordLab.Bot/API/Features/TranslatableMessageField.cs
+++ b/DiscordLab.Bot/API/Features/TranslatableMessageField.cs
@@ -1,0 +1,78 @@
+namespace DiscordLab.Bot.API.Features;
+
+/// <summary>
+/// Represents a specific field that the <see cref="Features.TranslationBuilder::Build"/> can be executed on. 
+/// </summary>
+[Flags]
+public enum TranslatableMessageField
+{
+    /// <summary>
+    /// Does not mark any fields for translation.
+    /// </summary>
+    None = 0,
+    
+    /// <summary>
+    /// Marks the <see cref="Features.MessageContent::Message"/> for parsing placeholders.
+    /// </summary>
+    Message = 1 << 0,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedBuilder::Title"/> for parsing placeholders.
+    /// </summary>
+    EmbedTitle = 1 << 1,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedBuilder::Description"/> for parsing placeholders.
+    /// </summary>
+    EmbedDescription = 1 << 2,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedBuilder::ThumbnailUrl"/> for parsing placeholders.
+    /// </summary>
+    EmbedThumbnailUrl = 1 << 3,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedBuilder::ImageUrl"/> for parsing placeholders.
+    /// </summary>
+    EmbedImageUrl = 1 << 4,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedBuilder::Url"/> for parsing placeholders.
+    /// </summary>
+    EmbedUrl = 1 << 5,
+
+    /// <summary>
+    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder::Name"/> for parsing placeholders.
+    /// </summary>
+    EmbedFieldNames = 1 << 6,
+
+    /// <summary>
+    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder::Value"/> for parsing placeholders.
+    /// </summary>
+    EmbedFieldValues = 1 << 7,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::Name"/> for parsing placeholders.
+    /// </summary>
+    EmbedAuthorName = 1 << 8,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::Url"/> for parsing placeholders.
+    /// </summary>
+    EmbedAuthorUrl = 1 << 9,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::IconUrl"/> for parsing placeholders.
+    /// </summary>
+    EmbedAuthorIconUrl = 1 << 10,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder::Text"/> for parsing placeholders.
+    /// </summary>
+    EmbedFooterText = 1 << 11,
+
+    /// <summary>
+    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder::IconUrl"/> for parsing placeholders.
+    /// </summary>
+    EmbedFooterIconUrl = 1 << 12,
+}

--- a/DiscordLab.Bot/API/Features/TranslatableMessageField.cs
+++ b/DiscordLab.Bot/API/Features/TranslatableMessageField.cs
@@ -1,7 +1,7 @@
 namespace DiscordLab.Bot.API.Features;
 
 /// <summary>
-/// Represents a specific field that the <see cref="Features.TranslationBuilder::Build"/> can be executed on. 
+/// Represents a specific field that the <see cref="Features.TranslationBuilder.Build"/> can be executed on.
 /// </summary>
 [Flags]
 public enum TranslatableMessageField
@@ -10,69 +10,69 @@ public enum TranslatableMessageField
     /// Does not mark any fields for translation.
     /// </summary>
     None = 0,
-    
+
     /// <summary>
-    /// Marks the <see cref="Features.MessageContent::Message"/> for parsing placeholders.
+    /// Marks the <see cref="Features.MessageContent.Message"/> for parsing placeholders.
     /// </summary>
     Message = 1 << 0,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedBuilder::Title"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedBuilder.Title"/> for parsing placeholders.
     /// </summary>
     EmbedTitle = 1 << 1,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedBuilder::Description"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedBuilder.Description"/> for parsing placeholders.
     /// </summary>
     EmbedDescription = 1 << 2,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedBuilder::ThumbnailUrl"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedBuilder.ThumbnailUrl"/> for parsing placeholders.
     /// </summary>
     EmbedThumbnailUrl = 1 << 3,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedBuilder::ImageUrl"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedBuilder.ImageUrl"/> for parsing placeholders.
     /// </summary>
     EmbedImageUrl = 1 << 4,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedBuilder::Url"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedBuilder.Url"/> for parsing placeholders.
     /// </summary>
     EmbedUrl = 1 << 5,
 
     /// <summary>
-    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder::Name"/> for parsing placeholders.
+    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder.Name"/> for parsing placeholders.
     /// </summary>
     EmbedFieldNames = 1 << 6,
 
     /// <summary>
-    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder::Value"/> for parsing placeholders.
+    /// Marks all the embed's <see cref="Embed.EmbedFieldBuilder.Value"/> for parsing placeholders.
     /// </summary>
     EmbedFieldValues = 1 << 7,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::Name"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder.Name"/> for parsing placeholders.
     /// </summary>
     EmbedAuthorName = 1 << 8,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::Url"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder.Url"/> for parsing placeholders.
     /// </summary>
     EmbedAuthorUrl = 1 << 9,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder::IconUrl"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedAuthorBuilder.IconUrl"/> for parsing placeholders.
     /// </summary>
     EmbedAuthorIconUrl = 1 << 10,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder::Text"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder.Text"/> for parsing placeholders.
     /// </summary>
     EmbedFooterText = 1 << 11,
 
     /// <summary>
-    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder::IconUrl"/> for parsing placeholders.
+    /// Marks the embed's <see cref="Embed.EmbedFooterBuilder.IconUrl"/> for parsing placeholders.
     /// </summary>
     EmbedFooterIconUrl = 1 << 12,
 }


### PR DESCRIPTION
This config option allows the user to specify which parts of a MessageContent should have it's {placeholder}s parsed.
It parses the same placeholders as it used to (Message, EmbedDescription, EmbedFieldValue, EmbedFooterText) by default.