### PR TITLE
fix: MessageContent::Build being called too late

### DIFF
--- a/DiscordLab.Bot/API/Features/MessageContent.cs
+++ b/DiscordLab.Bot/API/Features/MessageContent.cs
@@ -73,7 +73,8 @@ public class MessageContent
             throw new ArgumentNullException(nameof(builder));
 
         MethodBase method = new StackFrame(1).GetMethod();
-        Task.RunAndLog(async () => await SendToChannelAsync(channel, builder), ex => LoggingUtils.LogMethodError(ex, method));
+        (Discord.Embed? embed, string? content) = Build(builder);
+        Task.RunAndLog(async () => await channel.SendMessageAsync(content, embed: embed), ex => LoggingUtils.LogMethodError(ex, method));
     }
 
     /// <summary>


### PR DESCRIPTION
MessageContent::Build is called on the main thread fixing the Unity crashes, but this is at a cost of data accuracy.

The old system used data from when the event occurred, but the new system can be 1 Frame/Tick too late causing some data to be unusable.

An example of this is how DeathLogs would have the Player's (person who is killed) role be replaced with the role before they died (useful), but with the new system calling the builder 1 frame later causes it to be always set to Spectator.

This could be potentially also fixed by using some sort of snapshot system where data that can be used is fed into the translation methods generating delegates which will return the correct data based on the player or simply by having a custom class which will store all necessary player data.