### PR TITLE
fix: player left would be logged even if player is null

### DIFF
--- a/DiscordLab.ConnectionLogs/Events.cs
+++ b/DiscordLab.ConnectionLogs/Events.cs
@@ -45,6 +45,9 @@ public class Events : CustomEventsHandler
         if (Config.LeaveChannelId == 0)
             return;
 
+        if (ev.Player?.IsReady != true)
+            return;
+
         if (!Client.TryGetOrAddChannel(Config.LeaveChannelId, out SocketTextChannel channel))
         {
             Logger.Error(


### PR DESCRIPTION
This PR fixes a bug where the Leave Logs would be sent even though the ev.Player is null resulting in logs having incorrect / incomplete parsing.